### PR TITLE
Allow type "dll" dependencies

### DIFF
--- a/components/dotnet-core/src/main/java/npanday/ArtifactType.java
+++ b/components/dotnet-core/src/main/java/npanday/ArtifactType.java
@@ -121,6 +121,12 @@ public enum ArtifactType
      */
     @Deprecated
     LIBRARY( "library", "library", "dll" ),
+
+    /**
+     * Use DOTNET_LIBRARY instead
+     */
+    @Deprecated
+    DLL( "dll", "library", "dll" ),
     
     /** 
      * Use DOTNET_EXECUTABLE instead

--- a/components/dotnet-core/src/main/java/npanday/ArtifactTypeHelper.java
+++ b/components/dotnet-core/src/main/java/npanday/ArtifactTypeHelper.java
@@ -59,7 +59,8 @@ public class ArtifactTypeHelper
     {
         return packaging.equals( ArtifactType.DOTNET_LIBRARY )
                 || packaging.equals( ArtifactType.COM_REFERENCE )
-                || packaging.equals( ArtifactType.LIBRARY );
+                || packaging.equals( ArtifactType.LIBRARY )
+                || packaging.equals( ArtifactType.DLL );
     }
 
     public static boolean isDotnetModule(String packaging)

--- a/components/dotnet-executable/src/main/java/npanday/executable/impl/CompilerContextImpl.java
+++ b/components/dotnet-executable/src/main/java/npanday/executable/impl/CompilerContextImpl.java
@@ -45,7 +45,6 @@ import org.codehaus.plexus.logging.LogEnabled;
 import org.codehaus.plexus.logging.Logger;
 import org.codehaus.plexus.util.DirectoryScanner;
 import org.codehaus.plexus.util.FileUtils;
-import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.PathTool;
 
 import java.io.File;
@@ -388,8 +387,9 @@ public final class CompilerContextImpl
             for ( Artifact artifact : artifacts )
             {
                 String type = artifact.getType();
-                logger.debug( "NPANDAY-061-006: Artifact Type:" + type );
-                logger.debug( "NPANDAY-061-007: Artifact Type:" + ArtifactTypeHelper.isDotnetGenericGac( type ) );
+                logger.debug( "NPANDAY-061-003: Artifact Id:" + artifact.getArtifactId() );
+                logger.debug( "NPANDAY-061-004: Artifact Type:" + type );
+//                logger.debug( "NPANDAY-061-007: Artifact Type:" + ArtifactTypeHelper.isDotnetGenericGac( type ) );
                 ArtifactType artifactType = ArtifactType.getArtifactTypeForPackagingName( type );
                 if ( ArtifactTypeHelper.isDotnetModule( type ) )
                 {

--- a/plugins/maven-compile-plugin/src/main/groovy/npanday/plugin/compile/CompileLifecycleMap.groovy
+++ b/plugins/maven-compile-plugin/src/main/groovy/npanday/plugin/compile/CompileLifecycleMap.groovy
@@ -58,7 +58,7 @@ class CompileLifecycleMap extends LifecycleMap
 		forTypes([
 
                 /* --> DLL */
-                ArtifactType.DOTNET_LIBRARY, ArtifactType.LIBRARY,
+                ArtifactType.DOTNET_LIBRARY, ArtifactType.LIBRARY, ArtifactType.DLL,
                 /* see https://issues.apache.org/jira/browse/NPANDAY-526 */
                 ArtifactType.SHARP_DEVELOP_ADDIN, ArtifactType.VISUAL_STUDIO_ADDIN,
 


### PR DESCRIPTION
Hi,
I have added the possibility to use also dependencies with type "dll". This was necessary for releasing a project that have both Java and C# modules. 
If there is no problem with this code, please add it to your next release of NPanday.

Thanks,
Octavian
